### PR TITLE
feat: support advanced metadata filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,45 @@
 # chroma-java
 
-A minimal, embeddable in-memory vector database for Java 17 inspired by the core
-usage of [`chroma-core/chroma`](https://github.com/chroma-core/chroma). The
-implementation keeps everything in memory and is delivered as a single JAR with
-no runtime dependencies beyond the JDK.
+chroma-java 是一个受 [`chroma-core/chroma`](https://github.com/chroma-core/chroma) 启发、能够嵌入到任意 Java 17 应用中的内存向量数据库实现。该项目以单个 JAR 的形式提供，不依赖任何第三方运行时库，便于直接打包和分发。
 
-## Features
+## 项目简介与流程
 
-- Create named collections with a fixed vector dimension using `DB.createCollection`.
-- Batch `add`, `upsert`, `delete`, `getByIds`, and cosine-similarity `query`
-  operations with optional documents and metadata.
-- Cosine distance (1 - cosine similarity) search with simple metadata equality
-  filtering and controllable result payload (`Include` flags).
-- Thread-safe collections: writes are serialized, reads can happen concurrently.
-- Pure Java 17 implementation suitable for embedding in any JVM-based
-  application.
+整个项目旨在提供“开箱即用”的 Java 内存向量数据库，所有数据都会保留在 JVM 堆内，进程结束后不会自动持久化。其核心流程可分为两层：快速概览与代码级细节。
 
-## Building & Testing
+### 快速流程概览
 
-Compile the sources and run the lightweight test harness using only the JDK:
+1. **创建集合**：通过 `DB.createCollection(name, dimension)` 创建或获取一个指定名称和向量维度的集合。集合由 `VectorCollection` 表示，并使用读写锁保证线程安全。
+2. **写入数据**：调用 `VectorCollection.add` 或 `VectorCollection.upsert` 批量写入 ID、向量、可选的文档与元数据。内部会验证维度、复制向量并计算范数，最终以 `VectorRecord` 的形式存储在内存映射中。
+3. **查询数据**：通过 `VectorCollection.query` 传入查询向量、`topK` 数量以及可选的元数据过滤条件，集合会对当前快照逐条计算余弦距离并返回最近的若干条记录。
+4. **消费结果**：查询结果封装在 `QueryResult` 中，可按需获取 ID、距离、向量、文档和元数据；而按 ID 检索时则会得到 `CollectionResult`。调用方可以使用这些不可变结果对象安全地读取数据。
+
+### 核心代码流程详解
+
+**DB.createCollection**
+: 使用 `ConcurrentHashMap.compute` 原子地创建集合，当集合名称已存在时会校验维度是否一致，并直接返回现有实例。这样可以确保同名集合在多线程环境下也只会生成一个 `VectorCollection` 对象。
+
+**VectorCollection.add / upsert**
+: 这两个方法最终都会调用内部的 `storeBatch`。在申请写锁之前，`storeBatch` 会逐条检查 ID 是否为空、向量维度是否匹配并复制成新的数组，然后计算 L2 范数并封装为 `VectorRecord`。如果是 `add` 调用，还会在落盘前再次确认没有重复 ID。所有数据最后都会被写入内存中的 `HashMap`，因此需要预留足够的堆内存。
+
+**VectorCollection.query**
+: 查询时首先获取读锁并复制一份当前的记录快照，避免长时间阻塞写线程。随后针对每个查询向量计算范数、执行线性扫描，通过优先队列维护距离最近的 `topK` 条记录，并按请求决定是否附带向量、文档或元数据。
+
+**结果封装**
+: `CollectionResult` 和 `QueryResult` 都是只读的结果包装器，内部使用不可变集合暴露数据，避免调用方在读取后误改动底层结构。
+
+结合这些步骤，就可以清晰地理解从创建集合、写入数据到执行查询的完整代码路径。
+
+## 功能特性
+
+- 使用 `DB.createCollection` 创建具有固定维度的命名集合。
+- 支持批量 `add`、`upsert`、`delete`、`getByIds` 与基于余弦距离的 `query` 操作，可选携带文档与元数据。
+- 提供 `MetadataFilter` 组合等值、IN 与数值区间过滤，并通过 `Include` 枚举控制返回字段。
+- 集合内部使用读写锁实现线程安全：写操作串行化，读操作可并发执行。
+- 纯 Java 17 实现，易于嵌入任意 JVM 应用。
+
+## 构建与测试
+
+仅使用 JDK 即可编译源码并运行轻量级测试程序：
 
 ```bash
 rm -rf out
@@ -26,13 +47,13 @@ javac -d out $(find src/main/java -name "*.java") $(find src/test/java -name "*.
 java -ea -cp out com.chroma.simpledb.VectorCollectionTest
 ```
 
-To produce a single JAR containing the library and example entry point:
+如需打包成包含库与示例入口的单一 JAR，可执行：
 
 ```bash
 jar --create --file chroma-java.jar -C out .
 ```
 
-## Usage Example
+## 使用示例
 
 ```java
 VectorCollection collection = DB.createCollection("demo", 3);
@@ -51,10 +72,14 @@ collection.add(
     )
 );
 
+MetadataFilter filter = MetadataFilter.newBuilder()
+    .whereEquals("type", "summary")
+    .build();
+
 QueryResult result = collection.query(
     List.of(new double[]{0.8, 0.2, 0.0}),
     2,
-    Map.of("type", "summary"),
+    filter,
     EnumSet.of(Include.DOCUMENTS, Include.METADATA)
 );
 
@@ -62,14 +87,47 @@ System.out.println(result.getIds());
 System.out.println(result.getDistances());
 ```
 
-A runnable version of the snippet above is available in
-`src/main/java/com/chroma/simpledb/Example.java`.
+上述代码的可运行版本可在 `src/main/java/com/chroma/simpledb/Example.java` 中找到。
 
-## Design Notes
+若需要按照监控点编号和创建时间范围过滤，可以组合 `whereIn` 与数值区间条件：
 
-- Vectors are stored in their raw form and scanned linearly for queries to keep
-  the implementation simple while still supporting million-scale embeddings.
-- All data lives in the JVM process—there is no persistence layer or external
-  service dependency.
-- Dimension mismatches are rejected with an `IllegalArgumentException` to
-  surface errors early.
+```java
+MetadataFilter cameraFilter = MetadataFilter.newBuilder()
+    .whereIn("cameraNo", List.of("A01", "B06"))
+    .whereNumberGreaterThanOrEqual("createdAt", 1700000000000L)
+    .whereNumberLessThan("createdAt", 1700600000000L)
+    .build();
+```
+
+## 主要 API 说明
+
+### `VectorCollection.add` 的参数含义
+
+- `ids`：每条记录的唯一标识，不能为空、不可重复，并与向量列表的顺序一一对应。
+- `embeddings`：与 `ids` 对应的向量数组，长度必须与集合创建时声明的维度完全一致。
+- `documents`：与每条记录对应的可选文档内容，可为 `null`；若提供则列表长度需与 `ids` 一致。
+- `metadatas`：与每条记录对应的可选元数据字典，可为 `null`；若提供则列表长度需与 `ids` 一致。
+
+### `VectorCollection` 公共方法速览
+
+- `getName()`：返回集合的名称，同一名称在进程内指向唯一集合实例。
+- `getDimension()`：返回集合固定的向量维度，写入与查询向量必须满足该维度。
+- `size()`：返回当前集合持有的记录数量，读操作会在内部加锁以保证一致视图。
+- `add(...)`：批量写入新记录，不允许覆盖已有 ID，支持可选的文档与元数据。
+- `upsert(...)`：批量写入或覆盖记录，与 `add` 参数相同，若 ID 已存在则会替换原数据。
+- `deleteByIds(ids)`：根据 ID 列表删除记录，返回成功删除的条数。
+- `getByIds(ids, include)`：按 ID 批量读取记录，并通过 `include` 控制返回的字段，缺失的 ID 会被忽略。
+- `query(queries, topK, metadataFilter, include)`：执行余弦相似度查询，支持 `MetadataFilter` 组合等值、IN、数值范围过滤，并按距离升序返回前 `topK` 个结果。旧版仍可传入 `whereEq`（等值匹配），内部会自动转换为等价的 `MetadataFilter`。
+
+### `MetadataFilter` 常用构造方式
+
+- `whereEquals(key, value)`：要求元数据键的值等于指定对象（可为 `null`）。
+- `whereIn(key, candidates)`：要求元数据键的值命中候选列表中的任意一个。
+- `whereNumberGreaterThan/GreaterThanOrEqual`：数值字段需大于（或大于等于）指定阈值。
+- `whereNumberLessThan/LessThanOrEqual`：数值字段需小于（或小于等于）指定阈值，可与大于条件配合形成闭区间或开区间。
+
+## 设计说明
+
+- 向量以原始数组形式存储，查询时进行线性扫描，实现简单且可以支撑百万级别的嵌入。
+- 所有数据均常驻 JVM 内存，不依赖持久化层或外部服务。
+- 当检测到向量维度不匹配时，会抛出 `IllegalArgumentException` 以便尽早暴露错误。

--- a/src/main/java/com/chroma/simpledb/CollectionResult.java
+++ b/src/main/java/com/chroma/simpledb/CollectionResult.java
@@ -6,7 +6,9 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Result of {@link VectorCollection#getByIds(List, java.util.Set)}.
+ * 表示按 ID 检索集合时返回的结果。
+ * <p>
+ * 该结果对象不可变，并根据调用时的 include 参数判断是否实际携带向量、文档或元数据。
  */
 public final class CollectionResult {
 
@@ -34,18 +36,30 @@ public final class CollectionResult {
         this.metadatasIncluded = metadatasIncluded;
     }
 
+    /**
+     * 返回按输入顺序排列的记录 ID 列表。
+     */
     public List<String> getIds() {
         return ids;
     }
 
+    /**
+     * 返回可选的向量列表，只有在 include 中请求 EMBEDDINGS 时才会有值。
+     */
     public Optional<List<double[]>> getEmbeddings() {
         return embeddingsIncluded ? Optional.of(embeddings) : Optional.empty();
     }
 
+    /**
+     * 返回可选的文档列表，只有在 include 中请求 DOCUMENTS 时才会有值。
+     */
     public Optional<List<String>> getDocuments() {
         return documentsIncluded ? Optional.of(documents) : Optional.empty();
     }
 
+    /**
+     * 返回可选的元数据列表，只有在 include 中请求 METADATA 时才会有值。
+     */
     public Optional<List<Map<String, Object>>> getMetadatas() {
         return metadatasIncluded ? Optional.of(metadatas) : Optional.empty();
     }

--- a/src/main/java/com/chroma/simpledb/DB.java
+++ b/src/main/java/com/chroma/simpledb/DB.java
@@ -5,7 +5,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * Entry point for working with the in-memory vector database.
+ * 提供操作内存向量数据库的静态入口。
+ * <p>
+ * 所有集合都由该类统一管理，内部使用线程安全的 {@link ConcurrentHashMap}
+ * 按名称缓存 {@link VectorCollection} 实例，便于在不同调用方之间共享。
  */
 public final class DB {
 
@@ -15,11 +18,13 @@ public final class DB {
     }
 
     /**
-     * Create (or retrieve) a collection with the given name and vector dimension.
+     * 根据名称和向量维度创建或获取集合；若集合已存在则直接返回。
+     * <p>
+     * 当同一名称的集合已经创建时，会验证维度是否保持一致；若维度不同则抛出异常，避免出现混乱的数据结构。
      *
-     * @param name      collection name
-     * @param dimension vector dimension (must be &gt; 0)
-     * @return the collection instance
+     * @param name      集合名称，不能为空且不允许全是空白字符
+     * @param dimension 向量维度，必须为正数
+     * @return 对应的集合实例
      */
     public static VectorCollection createCollection(String name, int dimension) {
         Objects.requireNonNull(name, "name");
@@ -30,6 +35,7 @@ public final class DB {
             throw new IllegalArgumentException("Dimension must be positive");
         }
 
+        // 使用 ConcurrentHashMap 的 compute 方法原子地创建或返回已有集合
         return COLLECTIONS.compute(name, (key, existing) -> {
             if (existing != null) {
                 if (existing.getDimension() != dimension) {
@@ -43,17 +49,17 @@ public final class DB {
     }
 
     /**
-     * Retrieve a collection by name.
+     * 根据集合名称获取对应实例；若不存在则返回 {@code null}。
      *
-     * @param name collection name
-     * @return the collection or {@code null} if absent
+     * @param name 集合名称
+     * @return 集合实例或 {@code null}
      */
     public static VectorCollection getCollection(String name) {
         return COLLECTIONS.get(name);
     }
 
     /**
-     * Remove all collections. Intended for tests/demo reset.
+     * 清空所有集合，主要用于测试或示例复位。
      */
     public static void clear() {
         COLLECTIONS.clear();

--- a/src/main/java/com/chroma/simpledb/Example.java
+++ b/src/main/java/com/chroma/simpledb/Example.java
@@ -4,13 +4,17 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Small demo showing how to use the in-memory database.
+ * 用一个简短示例演示如何使用内存向量数据库。
+ * <p>
+ * 运行该入口类即可看到集合创建、写入与查询的完整流程输出。
  */
 public final class Example {
 
     public static void main(String[] args) {
+        // 创建一个维度为 3、名为 demo 的向量集合
         VectorCollection collection = DB.createCollection("demo", 3);
 
+        // 批量写入三条带有文档与元数据的向量记录
         collection.add(
                 List.of("a", "b", "c"),
                 List.of(
@@ -26,13 +30,18 @@ public final class Example {
                 )
         );
 
+        // 使用余弦距离查询与查询向量最接近的两个结果，并返回文档与元数据
+        MetadataFilter filter = MetadataFilter.newBuilder()
+                .whereEquals("type", "summary")
+                .build();
         QueryResult result = collection.query(
                 List.of(new double[]{0.8, 0.2, 0.0}),
                 2,
-                Map.of("type", "summary"),
+                filter,
                 java.util.EnumSet.of(Include.DOCUMENTS, Include.METADATA)
         );
 
+        // 打印查询得到的 ID、距离、文档与元数据
         System.out.println("Query IDs: " + result.getIds());
         System.out.println("Query distances: " + result.getDistances());
         result.getDocuments().ifPresent(docs -> System.out.println("Documents: " + docs));

--- a/src/main/java/com/chroma/simpledb/Include.java
+++ b/src/main/java/com/chroma/simpledb/Include.java
@@ -1,7 +1,7 @@
 package com.chroma.simpledb;
 
 /**
- * Controls which optional fields are returned from read operations.
+ * 控制读取操作返回哪些可选字段的枚举。
  */
 public enum Include {
     EMBEDDINGS,

--- a/src/main/java/com/chroma/simpledb/MetadataFilter.java
+++ b/src/main/java/com/chroma/simpledb/MetadataFilter.java
@@ -1,0 +1,244 @@
+package com.chroma.simpledb;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 用于描述查询时的元数据过滤条件。
+ * <p>
+ * 支持以下三类约束：
+ * <ul>
+ *     <li>等值匹配：键对应的值需要与指定对象完全一致；</li>
+ *     <li>IN 匹配：键对应的值必须命中给定列表中的任意一个候选值；</li>
+ *     <li>数值区间：键对应的值需要在设定的最小/最大阈值范围内（用于时间戳等数值字段）。</li>
+ * </ul>
+ * 使用 {@link Builder} 可以直观地组合上述条件；若三类约束都为空，则视为不过滤。
+ */
+public final class MetadataFilter {
+
+    private static final MetadataFilter EMPTY = new MetadataFilter(Map.of(), Map.of(), Map.of());
+
+    private final Map<String, Object> equalsConditions;
+    private final Map<String, List<Object>> inConditions;
+    private final Map<String, NumberRange> numberRanges;
+
+    private MetadataFilter(Map<String, Object> equalsConditions,
+                           Map<String, List<Object>> inConditions,
+                           Map<String, NumberRange> numberRanges) {
+        this.equalsConditions = equalsConditions;
+        this.inConditions = inConditions;
+        this.numberRanges = numberRanges;
+    }
+
+    /**
+     * 创建一个空过滤器，等价于不设置任何元数据条件。
+     */
+    public static MetadataFilter empty() {
+        return EMPTY;
+    }
+
+    /**
+     * 仅使用等值匹配初始化过滤器，供保持旧版 API 行为时使用。
+     */
+    static MetadataFilter fromEquals(Map<String, Object> equalsConditions) {
+        if (equalsConditions == null || equalsConditions.isEmpty()) {
+            return empty();
+        }
+        Map<String, Object> copy = new LinkedHashMap<>(equalsConditions);
+        return new MetadataFilter(Collections.unmodifiableMap(copy), Map.of(), Map.of());
+    }
+
+    /**
+     * 当且仅当三类条件均为空时返回 {@code true}。
+     */
+    boolean isEmpty() {
+        return equalsConditions.isEmpty() && inConditions.isEmpty() && numberRanges.isEmpty();
+    }
+
+    Map<String, Object> equalsConditions() {
+        return equalsConditions;
+    }
+
+    Map<String, List<Object>> inConditions() {
+        return inConditions;
+    }
+
+    Map<String, NumberRange> numberRanges() {
+        return numberRanges;
+    }
+
+    /**
+     * 创建一个新的过滤器构造器实例。
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * 描述单个数值字段的范围约束。
+     */
+    static final class NumberRange {
+        final Double min;
+        final boolean minInclusive;
+        final Double max;
+        final boolean maxInclusive;
+
+        NumberRange(Double min, boolean minInclusive, Double max, boolean maxInclusive) {
+            this.min = min;
+            this.minInclusive = minInclusive;
+            this.max = max;
+            this.maxInclusive = maxInclusive;
+        }
+    }
+
+    /**
+     * 负责逐步拼装 {@link MetadataFilter} 的构造器。
+     */
+    public static final class Builder {
+
+        private final Map<String, Object> equalsConditions = new LinkedHashMap<>();
+        private final Map<String, List<Object>> inConditions = new LinkedHashMap<>();
+        private final Map<String, NumberRange> numberRanges = new LinkedHashMap<>();
+
+        private Builder() {
+        }
+
+        /**
+         * 指定某个键必须等于给定的值（可为 {@code null}）。
+         */
+        public Builder whereEquals(String key, Object value) {
+            validateKey(key);
+            equalsConditions.put(key, value);
+            return this;
+        }
+
+        /**
+         * 指定某个键的值必须命中候选列表中的任意一个。
+         */
+        public Builder whereIn(String key, Collection<?> candidates) {
+            validateKey(key);
+            Objects.requireNonNull(candidates, "candidates");
+            if (candidates.isEmpty()) {
+                throw new IllegalArgumentException("candidates must not be empty");
+            }
+            List<Object> values = new ArrayList<>(candidates.size());
+            values.addAll(candidates);
+            inConditions.put(key, Collections.unmodifiableList(values));
+            return this;
+        }
+
+        /**
+         * 指定某个数值字段需要大于给定阈值（不包含）。
+         */
+        public Builder whereNumberGreaterThan(String key, Number minExclusive) {
+            return applyMin(key, minExclusive, false);
+        }
+
+        /**
+         * 指定某个数值字段需要大于等于给定阈值（包含）。
+         */
+        public Builder whereNumberGreaterThanOrEqual(String key, Number minInclusive) {
+            return applyMin(key, minInclusive, true);
+        }
+
+        /**
+         * 指定某个数值字段需要小于给定阈值（不包含）。
+         */
+        public Builder whereNumberLessThan(String key, Number maxExclusive) {
+            return applyMax(key, maxExclusive, false);
+        }
+
+        /**
+         * 指定某个数值字段需要小于等于给定阈值（包含）。
+         */
+        public Builder whereNumberLessThanOrEqual(String key, Number maxInclusive) {
+            return applyMax(key, maxInclusive, true);
+        }
+
+        /**
+         * 最终构造出不可变的 {@link MetadataFilter}。
+         */
+        public MetadataFilter build() {
+            if (equalsConditions.isEmpty() && inConditions.isEmpty() && numberRanges.isEmpty()) {
+                return MetadataFilter.empty();
+            }
+            Map<String, Object> equalsCopy = equalsConditions.isEmpty()
+                    ? Map.of()
+                    : Collections.unmodifiableMap(new LinkedHashMap<>(equalsConditions));
+            Map<String, List<Object>> inCopy;
+            if (inConditions.isEmpty()) {
+                inCopy = Map.of();
+            } else {
+                Map<String, List<Object>> tmp = new LinkedHashMap<>();
+                for (Map.Entry<String, List<Object>> entry : inConditions.entrySet()) {
+                    if (entry.getValue().isEmpty()) {
+                        throw new IllegalStateException("candidates must not be empty");
+                    }
+                    tmp.put(entry.getKey(), entry.getValue());
+                }
+                inCopy = Collections.unmodifiableMap(tmp);
+            }
+            Map<String, NumberRange> rangeCopy;
+            if (numberRanges.isEmpty()) {
+                rangeCopy = Map.of();
+            } else {
+                Map<String, NumberRange> tmp = new LinkedHashMap<>();
+                for (Map.Entry<String, NumberRange> entry : numberRanges.entrySet()) {
+                    NumberRange range = entry.getValue();
+                    if (range == null) {
+                        continue;
+                    }
+                    validateRange(entry.getKey(), range);
+                    tmp.put(entry.getKey(), range);
+                }
+                rangeCopy = Collections.unmodifiableMap(tmp);
+            }
+            return new MetadataFilter(equalsCopy, inCopy, rangeCopy);
+        }
+
+        private Builder applyMin(String key, Number min, boolean inclusive) {
+            validateKey(key);
+            Objects.requireNonNull(min, "min");
+            double value = min.doubleValue();
+            NumberRange current = numberRanges.get(key);
+            boolean maxInclusive = current != null && current.max != null && current.maxInclusive;
+            NumberRange updated = new NumberRange(value, inclusive, current == null ? null : current.max, maxInclusive);
+            numberRanges.put(key, updated);
+            return this;
+        }
+
+        private Builder applyMax(String key, Number max, boolean inclusive) {
+            validateKey(key);
+            Objects.requireNonNull(max, "max");
+            double value = max.doubleValue();
+            NumberRange current = numberRanges.get(key);
+            boolean minInclusive = current != null && current.min != null && current.minInclusive;
+            NumberRange updated = new NumberRange(current == null ? null : current.min, minInclusive, value, inclusive);
+            numberRanges.put(key, updated);
+            return this;
+        }
+
+        private void validateKey(String key) {
+            if (key == null || key.isBlank()) {
+                throw new IllegalArgumentException("metadata key must not be null or blank");
+            }
+        }
+
+        private void validateRange(String key, NumberRange range) {
+            if (range.min != null && range.max != null) {
+                int cmp = Double.compare(range.min, range.max);
+                if (cmp > 0) {
+                    throw new IllegalStateException("min must not be greater than max for key: " + key);
+                }
+                if (cmp == 0 && (!range.minInclusive || !range.maxInclusive)) {
+                    throw new IllegalStateException("exclusive bounds collapse range for key: " + key);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/chroma/simpledb/QueryResult.java
+++ b/src/main/java/com/chroma/simpledb/QueryResult.java
@@ -6,7 +6,9 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Result of a similarity query.
+ * 表示相似度查询返回的结果集合。
+ * <p>
+ * 每个查询向量都会对应一组有序的命中结果，内部结构同样是不可变的，只会在 include 中请求的字段才真正存储数据。
  */
 public final class QueryResult {
 
@@ -37,22 +39,37 @@ public final class QueryResult {
         this.metadatasIncluded = metadatasIncluded;
     }
 
+    /**
+     * 返回所有查询的命中 ID，外层列表与查询顺序一一对应。
+     */
     public List<List<String>> getIds() {
         return ids;
     }
 
+    /**
+     * 返回所有查询的距离结果，距离列表与 {@link #getIds()} 的结构一致。
+     */
     public List<List<Double>> getDistances() {
         return distances;
     }
 
+    /**
+     * 返回可选的向量结果，只有在 include 中请求 EMBEDDINGS 时才会有值。
+     */
     public Optional<List<List<double[]>>> getEmbeddings() {
         return embeddingsIncluded ? Optional.of(embeddings) : Optional.empty();
     }
 
+    /**
+     * 返回可选的文档结果，只有在 include 中请求 DOCUMENTS 时才会有值。
+     */
     public Optional<List<List<String>>> getDocuments() {
         return documentsIncluded ? Optional.of(documents) : Optional.empty();
     }
 
+    /**
+     * 返回可选的元数据结果，只有在 include 中请求 METADATA 时才会有值。
+     */
     public Optional<List<List<Map<String, Object>>>> getMetadatas() {
         return metadatasIncluded ? Optional.of(metadatas) : Optional.empty();
     }

--- a/src/main/java/com/chroma/simpledb/VectorCollection.java
+++ b/src/main/java/com/chroma/simpledb/VectorCollection.java
@@ -16,30 +16,55 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * Represents a named collection of dense vectors stored entirely in memory.
+ * 表示一个全部保存在内存中的命名稠密向量集合。
+ * <p>
+ * 该类负责管理所有写入、查询与删除操作，并通过读写锁协调并发访问。
  */
 public final class VectorCollection {
 
     private final String name;
     private final int dimension;
     private final Map<String, VectorRecord> records;
-    private final ReadWriteLock readWriteLock;
+    private final ReadWriteLock readWriteLock; // 控制并发读写的读写锁
 
     VectorCollection(String name, int dimension) {
         this.name = name;
         this.dimension = dimension;
         this.records = new HashMap<>();
-        this.readWriteLock = new ReentrantReadWriteLock();
+        this.readWriteLock = new ReentrantReadWriteLock(); // 默认提供公平的读写锁实现
     }
 
+    /**
+     * 获取该集合的唯一名称。
+     * <p>
+     * 名称在整个进程范围内用于区分不同集合，通过 {@link DB#createCollection(String, int)}
+     * 得到的同名集合都会指向这一实例。
+     *
+     * @return 集合名称
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * 返回集合在创建时声明的向量维度。
+     * <p>
+     * 所有写入或查询到该集合的向量都必须严格等于该维度，否则会抛出
+     * {@link IllegalArgumentException}。
+     *
+     * @return 固定的向量维度
+     */
     public int getDimension() {
         return dimension;
     }
 
+    /**
+     * 获取当前集合中记录的数量。
+     * <p>
+     * 方法内部加读锁，确保在有并发写入时能够得到一致的数量视图。
+     *
+     * @return 当前已存储的记录总数
+     */
     public int size() {
         Lock read = readWriteLock.readLock();
         read.lock();
@@ -50,33 +75,83 @@ public final class VectorCollection {
         }
     }
 
+    /**
+     * 以最小参数集批量写入多条记录。
+     * <p>
+     * 与四参版本相比，该方法默认不写入文档和元数据；四参版本会对所有参数做一致性校验。
+     * 该写入模式不允许覆盖已有的 ID。
+     *
+     * @param ids        需要写入的记录 ID，需唯一且与向量列表顺序对应
+     * @param embeddings 需要写入的向量数据，长度必须与 {@link #getDimension()} 相同
+     */
     public void add(List<String> ids, List<double[]> embeddings) {
         add(ids, embeddings, null, null);
     }
 
+    /**
+     * 批量写入记录，不允许覆盖已有 ID。
+     * <p>
+     * 所有列表参数必须等长：索引 <code>i</code> 处的 ID、向量、文档和元数据共同组成一条记录。
+     * 方法会复制向量、计算范数并校验维度，以保证后续查询的正确性。
+     *
+     * @param ids        记录的唯一标识，不能为空、不可重复
+     * @param embeddings 与每个 ID 对应的向量数据，维度固定且不能为空
+     * @param documents  与每个 ID 对应的可选文档内容，可传入 {@code null}
+     * @param metadatas  与每个 ID 对应的可选元数据字典，可传入 {@code null}
+     * @throws IllegalArgumentException 当列表长度不一致、ID 重复或维度不匹配时抛出
+     */
     public void add(List<String> ids,
                     List<double[]> embeddings,
                     List<String> documents,
                     List<Map<String, Object>> metadatas) {
+        // add 调用最终走向统一的批量写入逻辑，不允许覆盖已有记录
         storeBatch(ids, embeddings, documents, metadatas, false);
     }
 
+    /**
+     * 以最小参数集批量写入或更新多条记录。
+     *
+     * @param ids        需要写入的记录 ID，需与向量一一对应
+     * @param embeddings 需要写入的向量数据，长度必须与 {@link #getDimension()} 相同
+     */
     public void upsert(List<String> ids, List<double[]> embeddings) {
         upsert(ids, embeddings, null, null);
     }
 
+    /**
+     * 批量写入或覆盖已有记录。
+     * <p>
+     * 当 ID 已存在时，本方法会用提供的新向量、文档与元数据替换原有内容；其余规则与
+     * {@link #add(List, List, List, List)} 一致。
+     *
+     * @param ids        记录的唯一标识，不能为空
+     * @param embeddings 新的向量数据，维度必须匹配
+     * @param documents  可选的文档内容，为 {@code null} 时表示对应记录没有文档
+     * @param metadatas  可选的元数据字典，为 {@code null} 时表示对应记录没有元数据
+     * @throws IllegalArgumentException 当输入不满足长度或维度要求时抛出
+     */
     public void upsert(List<String> ids,
-                       List<double[]> embeddings,
-                       List<String> documents,
-                       List<Map<String, Object>> metadatas) {
+                    List<double[]> embeddings,
+                    List<String> documents,
+                    List<Map<String, Object>> metadatas) {
+        // upsert 在写入时允许覆盖已有记录
         storeBatch(ids, embeddings, documents, metadatas, true);
     }
 
+    /**
+     * 根据 ID 列表删除记录。
+     * <p>
+     * 方法会加写锁以串行化删除操作，返回成功删除的记录数量。
+     *
+     * @param ids 需要删除的 ID 列表
+     * @return 实际移除的记录条数
+     */
     public int deleteByIds(List<String> ids) {
         Objects.requireNonNull(ids, "ids");
         Lock write = readWriteLock.writeLock();
         write.lock();
         try {
+            // 写锁保护删除过程，逐个移除匹配的记录
             int removed = 0;
             for (String id : ids) {
                 if (records.remove(id) != null) {
@@ -89,10 +164,27 @@ public final class VectorCollection {
         }
     }
 
+    /**
+     * 按 ID 批量读取记录，返回完整的嵌入、文档与元数据。
+     * <p>
+     * 等价于调用 {@link #getByIds(List, Set)}，并默认请求所有可选字段。
+     *
+     * @param ids 需要查询的 ID 列表
+     * @return 按原始顺序返回的查询结果
+     */
     public CollectionResult getByIds(List<String> ids) {
         return getByIds(ids, EnumSet.of(Include.EMBEDDINGS, Include.DOCUMENTS, Include.METADATA));
     }
 
+    /**
+     * 按 ID 批量读取记录，并根据 include 参数控制返回字段。
+     * <p>
+     * 结果中只会包含集合里已存在的 ID，缺失的 ID 会被忽略。
+     *
+     * @param ids     需要查询的 ID 列表
+     * @param include 控制返回哪些字段的枚举集合，如未指定则默认只返回 ID
+     * @return {@link CollectionResult}，其中的列表均与输入 ID 顺序保持一致
+     */
     public CollectionResult getByIds(List<String> ids, Set<Include> include) {
         Objects.requireNonNull(ids, "ids");
         EnumSet<Include> includes = normalizeInclude(include);
@@ -108,6 +200,7 @@ public final class VectorCollection {
         Lock read = readWriteLock.readLock();
         read.lock();
         try {
+            // 逐个查找记录并根据 include 配置构造结果
             for (String id : ids) {
                 VectorRecord record = records.get(id);
                 if (record == null) {
@@ -134,13 +227,54 @@ public final class VectorCollection {
                 includeMetadatas ? resultMetadatas : List.of(), includeMetadatas);
     }
 
+    /**
+     * 使用给定的查询向量执行相似度搜索，返回最近的前 {@code topK} 条记录。
+     * <p>
+     * 等价于调用完整参数的 {@link #query(List, int, MetadataFilter, Set)} 且不进行元数据过滤，也不额外返回可选字段。
+     *
+     * @param queries 需要执行搜索的查询向量列表
+     * @param topK    每个查询返回的最大结果数，必须为正数
+     * @return 查询结果，包含每个查询命中的 ID 与距离
+     */
     public QueryResult query(List<double[]> queries, int topK) {
-        return query(queries, topK, null, EnumSet.noneOf(Include.class));
+        return query(queries, topK, MetadataFilter.empty(), EnumSet.noneOf(Include.class));
     }
 
+    /**
+     * 使用给定的查询向量执行相似度搜索，并支持元数据过滤及返回字段控制。
+     * <p>
+     * 这是为了兼容旧版接口而保留的等值过滤入口，内部会转换为 {@link MetadataFilter}。
+     *
+     * @param queries  需要执行搜索的查询向量列表，元素维度必须匹配集合
+     * @param topK     每个查询返回的最大结果数，必须为正
+     * @param whereEq  可选的元数据等值过滤条件，只有满足键值完全匹配的记录才会被返回
+     * @param include  控制返回哪些字段的枚举集合，例如 {@link Include#DOCUMENTS}
+     * @return {@link QueryResult}，包含每个查询对应的命中列表
+     * @throws IllegalArgumentException 当 {@code topK} 非正或查询向量维度不匹配时抛出
+     */
     public QueryResult query(List<double[]> queries,
                              int topK,
                              Map<String, Object> whereEq,
+                             Set<Include> include) {
+        MetadataFilter filter = MetadataFilter.fromEquals(whereEq);
+        return query(queries, topK, filter, include);
+    }
+
+    /**
+     * 使用给定的查询向量执行相似度搜索，并支持组合的元数据过滤条件。
+     * <p>
+     * 搜索过程中会对所有记录进行线性扫描，采用余弦距离对结果排序，并逐项应用 {@link MetadataFilter}。
+     *
+     * @param queries        需要执行搜索的查询向量列表，元素维度必须匹配集合
+     * @param topK           每个查询返回的最大结果数，必须为正
+     * @param metadataFilter 支持等值、IN 与数值区间的元数据过滤条件
+     * @param include        控制返回哪些字段的枚举集合，例如 {@link Include#DOCUMENTS}
+     * @return {@link QueryResult}，包含每个查询对应的命中列表
+     * @throws IllegalArgumentException 当 {@code topK} 非正或查询向量维度不匹配时抛出
+     */
+    public QueryResult query(List<double[]> queries,
+                             int topK,
+                             MetadataFilter metadataFilter,
                              Set<Include> include) {
         Objects.requireNonNull(queries, "queries");
         if (topK <= 0) {
@@ -149,6 +283,8 @@ public final class VectorCollection {
         for (double[] query : queries) {
             validateVector(query);
         }
+
+        MetadataFilter normalizedFilter = metadataFilter == null ? MetadataFilter.empty() : metadataFilter;
 
         EnumSet<Include> includes = normalizeInclude(include);
         boolean includeEmbeddings = includes.contains(Include.EMBEDDINGS);
@@ -164,10 +300,11 @@ public final class VectorCollection {
         Lock read = readWriteLock.readLock();
         read.lock();
         try {
+            // 拷贝一份当前数据快照，避免查询期间阻塞写操作
             List<VectorRecord> snapshot = new ArrayList<>(records.values());
             for (double[] query : queries) {
                 double queryNorm = l2Norm(query);
-                List<ScoredRecord> scored = topKRecords(snapshot, query, queryNorm, topK, whereEq);
+                List<ScoredRecord> scored = topKRecords(snapshot, query, queryNorm, topK, normalizedFilter);
                 List<String> idsForQuery = new ArrayList<>(scored.size());
                 List<Double> distancesForQuery = new ArrayList<>(scored.size());
                 List<double[]> embeddingsForQuery = includeEmbeddings ? new ArrayList<>(scored.size()) : null;
@@ -225,6 +362,7 @@ public final class VectorCollection {
         List<String> normalizedDocuments = normalizeOptionalList(documents, ids.size(), "documents");
         List<Map<String, Object>> normalizedMetadatas = normalizeOptionalList(metadatas, ids.size(), "metadatas");
 
+        // 预先构建待写入的记录，确保所有校验在获取写锁之前完成
         List<VectorRecord> newRecords = new ArrayList<>(ids.size());
         for (int i = 0; i < ids.size(); i++) {
             String id = ids.get(i);
@@ -233,6 +371,7 @@ public final class VectorCollection {
             }
             double[] embedding = embeddings.get(i);
             validateVector(embedding);
+            // 复制向量避免外部修改，并提前计算范数提高查询效率
             double[] embeddingCopy = Arrays.copyOf(embedding, embedding.length);
             double norm = l2Norm(embeddingCopy);
             String document = normalizedDocuments.get(i);
@@ -244,12 +383,14 @@ public final class VectorCollection {
         write.lock();
         try {
             if (!allowOverwrite) {
+                // 如果不允许覆盖，则先检测是否存在重复 ID
                 for (VectorRecord newRecord : newRecords) {
                     if (records.containsKey(newRecord.id())) {
                         throw new IllegalArgumentException("id already exists: " + newRecord.id());
                     }
                 }
             }
+            // 将记录写入内存映射
             for (VectorRecord newRecord : newRecords) {
                 records.put(newRecord.id(), newRecord);
             }
@@ -262,10 +403,11 @@ public final class VectorCollection {
                                            double[] query,
                                            double queryNorm,
                                            int topK,
-                                           Map<String, Object> whereEq) {
+                                           MetadataFilter metadataFilter) {
+        // 使用大顶堆保留当前最优的 topK 结果
         PriorityQueue<ScoredRecord> heap = new PriorityQueue<>(Comparator.comparingDouble((ScoredRecord s) -> s.distance).reversed());
         for (VectorRecord record : snapshot) {
-            if (!record.matchesWhereEq(whereEq)) {
+            if (!record.matchesFilter(metadataFilter)) {
                 continue;
             }
             double distance = cosineDistance(query, queryNorm, record);
@@ -275,6 +417,7 @@ public final class VectorCollection {
             if (heap.size() < topK) {
                 heap.offer(new ScoredRecord(record, distance));
             } else if (distance < heap.peek().distance) {
+                // 只保留距离更近的候选
                 heap.poll();
                 heap.offer(new ScoredRecord(record, distance));
             }
@@ -285,6 +428,7 @@ public final class VectorCollection {
     }
 
     private double cosineDistance(double[] query, double queryNorm, VectorRecord record) {
+        // 将余弦相似度转化为距离（1 - cosine），并避免出现负值
         double cosine = cosineSimilarity(query, record.embedding(), queryNorm, record.norm());
         double distance = 1.0 - cosine;
         if (distance < 0.0) {
@@ -294,6 +438,7 @@ public final class VectorCollection {
     }
 
     private double cosineSimilarity(double[] a, double[] b, double normA, double normB) {
+        // 预先计算好的范数为相似度计算提供加速
         if (normA == 0.0 || normB == 0.0) {
             return 0.0;
         }
@@ -305,6 +450,7 @@ public final class VectorCollection {
     }
 
     private double l2Norm(double[] vector) {
+        // 计算向量的 L2 范数，用于后续的余弦相似度
         double sum = 0.0;
         for (double v : vector) {
             sum += v * v;
@@ -313,6 +459,7 @@ public final class VectorCollection {
     }
 
     private void validateVector(double[] vector) {
+        // 检查向量对象是否存在以及维度是否满足集合要求
         if (vector == null) {
             throw new IllegalArgumentException("embedding must not be null");
         }
@@ -324,6 +471,7 @@ public final class VectorCollection {
 
     private <T> List<T> normalizeOptionalList(List<T> values, int expectedSize, String fieldName) {
         if (values == null) {
+            // 如果缺失则补齐为指定长度的 null 列表，便于统一处理
             List<T> result = new ArrayList<>(expectedSize);
             for (int i = 0; i < expectedSize; i++) {
                 result.add(null);
@@ -340,6 +488,7 @@ public final class VectorCollection {
         if (metadata == null || metadata.isEmpty()) {
             return null;
         }
+        // 保留插入顺序，避免调用方修改原始 map
         return new java.util.LinkedHashMap<>(metadata);
     }
 
@@ -347,6 +496,7 @@ public final class VectorCollection {
         if (metadata == null || metadata.isEmpty()) {
             return Map.of();
         }
+        // 返回不可变视图，确保结果对象只读
         return Collections.unmodifiableMap(new java.util.LinkedHashMap<>(metadata));
     }
 
@@ -354,6 +504,7 @@ public final class VectorCollection {
         if (include == null || include.isEmpty()) {
             return EnumSet.noneOf(Include.class);
         }
+        // 使用 EnumSet 提升 contains 判断效率
         return EnumSet.copyOf(include);
     }
 

--- a/src/test/java/com/chroma/simpledb/VectorCollectionTest.java
+++ b/src/test/java/com/chroma/simpledb/VectorCollectionTest.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Lightweight test harness without external dependencies.
+ * 使用纯 JDK 编写的轻量级测试入口，无需额外依赖。
  */
 public final class VectorCollectionTest {
 
@@ -14,6 +14,7 @@ public final class VectorCollectionTest {
         VectorCollectionTest test = new VectorCollectionTest();
         test.addAndQueryReturnsNearest();
         test.metadataFilterLimitsResults();
+        test.metadataFilterSupportsInAndRange();
         test.dimensionMismatchThrows();
         test.upsertReplacesExisting();
         test.deleteRemovesEntries();
@@ -81,6 +82,44 @@ public final class VectorCollectionTest {
 
         assertEquals(List.of(List.of("x")), filtered.getIds(), "Metadata filter should only return matching id");
         assertEquals(1, filtered.getDistances().get(0).size(), "Unexpected number of distances after filtering");
+    }
+
+    private void metadataFilterSupportsInAndRange() {
+        DB.clear();
+        VectorCollection collection = DB.createCollection("filter-advanced", 2);
+        collection.add(
+                List.of("cam-1", "cam-2", "cam-3"),
+                List.of(
+                        new double[]{1.0, 0.0},
+                        new double[]{0.95, 0.05},
+                        new double[]{0.8, 0.2}
+                ),
+                null,
+                List.of(
+                        Map.of("cameraNo", "A01", "createdAt", 1700000000000L),
+                        Map.of("cameraNo", "A02", "createdAt", 1700000004000L),
+                        Map.of("cameraNo", "B01", "createdAt", 1700100000000L)
+                )
+        );
+
+        MetadataFilter filter = MetadataFilter.newBuilder()
+                .whereIn("cameraNo", List.of("A02", "B01"))
+                .whereNumberGreaterThanOrEqual("createdAt", 1700000004000L)
+                .whereNumberLessThan("createdAt", 1700200000000L)
+                .build();
+
+        QueryResult result = collection.query(
+                List.of(new double[]{0.94, 0.06}),
+                3,
+                filter,
+                EnumSet.of(Include.METADATA)
+        );
+
+        assertEquals(List.of(List.of("cam-2", "cam-3")), result.getIds(), "IN + 范围过滤结果不符合预期");
+        assertTrue(result.getMetadatas().isPresent(), "元数据应被包含在结果中");
+        List<Map<String, Object>> metadatas = result.getMetadatas().get().get(0);
+        assertEquals("A02", metadatas.get(0).get("cameraNo"), "首条记录 cameraNo 不正确");
+        assertEquals("B01", metadatas.get(1).get("cameraNo"), "次条记录 cameraNo 不正确");
     }
 
     private void dimensionMismatchThrows() {


### PR DESCRIPTION
## Summary
- introduce a MetadataFilter builder that supports equals, IN and numeric range predicates
- update VectorCollection query logic and documentation to apply the new filter while keeping the map-based overload
- refresh examples, README guidance and tests to cover cameraNo IN and createdAt range scenarios

## Testing
- javac -d out $(find src/main/java -name "*.java") $(find src/test/java -name "*.java")
- java -ea -cp out com.chroma.simpledb.VectorCollectionTest

------
https://chatgpt.com/codex/tasks/task_e_68d365c22c88832ba879ffcfb6744778